### PR TITLE
Replaced unwrap call when loading wager with helper function

### DIFF
--- a/contracts/wager/src/contract.rs
+++ b/contracts/wager/src/contract.rs
@@ -129,10 +129,7 @@ pub fn execute_cancel(
 ) -> Result<Response, ContractError> {
     let wager = get_wager(&deps, &wager_id)?;
 
-    if info.sender == ""
-        || (info.sender != wager.user1 && info.sender != wager.arbiter)
-        || wager.user2 != "empty"
-    {
+    if (info.sender != wager.user1 && info.sender != wager.arbiter) || wager.user2 != "empty" {
         Err(ContractError::Unauthorized {})
     } else {
         WAGERS.remove(deps.storage, &wager_id);

--- a/contracts/wager/src/contract.rs
+++ b/contracts/wager/src/contract.rs
@@ -97,7 +97,7 @@ pub fn execute_add_funds(
     balance: Balance,
     wager_id: String,
 ) -> Result<Response, ContractError> {
-    let mut wager = WAGERS.load(deps.storage, &wager_id).unwrap();
+    let mut wager = get_wager(&deps, &wager_id)?;
 
     if wager.user2 != "empty" || wager.user1 == info.sender {
         return Err(ContractError::AlreadyInUse {});
@@ -127,7 +127,7 @@ pub fn execute_cancel(
     info: MessageInfo,
     wager_id: String,
 ) -> Result<Response, ContractError> {
-    let wager = WAGERS.load(deps.storage, &wager_id).unwrap();
+    let wager = get_wager(&deps, &wager_id)?;
 
     if info.sender == ""
         || (info.sender != wager.user1 && info.sender != wager.arbiter)
@@ -154,7 +154,7 @@ pub fn execute_send_funds(
     wager_id: String,
     winner_address: Addr,
 ) -> Result<Response, ContractError> {
-    let wager = WAGERS.load(deps.storage, &wager_id).unwrap();
+    let wager = get_wager(&deps, &wager_id)?;
     let state = config(deps.storage).load()?;
 
     if info.sender != state.owner {
@@ -176,6 +176,13 @@ pub fn execute_send_funds(
             .add_attribute("to", winner_address)
             .add_submessages(user1_messages)
             .add_submessages(user2_messages))
+    }
+}
+
+fn get_wager(deps: &DepsMut, wager_id: &str) -> Result<Wager, ContractError> {
+    match WAGERS.load(deps.storage, wager_id) {
+        Ok(wager) => Ok(wager),
+        Err(_) => Err(ContractError::WagerDoesNotExist {}),
     }
 }
 


### PR DESCRIPTION
1. Created function `get_wager(...)` which attempts to load a wager by id and returns an error if it doesn't exist.
2. Replaced all `WAGER.load(...)` calls with this
3. Removed unnecessary check if `info.sender == ""` in `execute_cancel(...)` function.