### PR TITLE
Renamed wager contract from 'duel-dojo' and tweaked github action

### DIFF
--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -22,8 +22,7 @@ jobs:
           docker run --rm -v "$(pwd)":/code \
           --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
           --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-          cosmwasm/rust-optimizer:0.11.5
-          tar -zcvf cosmwasm-artifacts.tar.gz artifacts
+          cosmwasm/workspace-optimizer:0.11.5
 #       TODO: implement releases
 #      - name: Create Release
 #        uses: softprops/action-gh-release@v1

--- a/contracts/wager/Cargo.toml
+++ b/contracts/wager/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "duel-dojo"
+name = "wager"
 version = "0.1.0"
 authors = ["Vlad <vladjdk@gmail.com>"]
 edition = "2018"

--- a/contracts/wager/examples/schema.rs
+++ b/contracts/wager/examples/schema.rs
@@ -3,8 +3,8 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
-use duel_dojo::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use duel_dojo::state::{GenericBalance, State, Wager};
+use wager::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use wager::state::{GenericBalance, State, Wager};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();


### PR DESCRIPTION
1.  Renamed wager contract to 'wager' from 'duel-dojo' in its `Cargo.toml`

2. Replaced optimize command `cosmwasm/rust-optimizer:0.11.5` with `cosmwasm/workspace-optimizer:0.11.5` which will optimize all contracts in the `contracts/` directory and put them into `artifacts/`.